### PR TITLE
Use --rebuild option for build.sh (see Bug 1564875)

### DIFF
--- a/nss-ssl-gtests.sh
+++ b/nss-ssl-gtests.sh
@@ -86,7 +86,11 @@ while [ $# -ge 1 ]; do
 done
 
 if [[ "$build" = 1 ]]; then
-    ~/code/nss/build.sh || exit 1
+    build_args=()
+    if [[ -e "$root/dist/build_args" ]]; then
+        build_args+=(--rebuild)
+    fi
+    ~/code/nss/build.sh "${build_args[@]}" || exit 1
 fi
 
 dist="$root/dist/$(cat "$root/dist/latest")"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1564875 explains how this is useful.  This supports the following workflow:

```sh
./build.sh --asan --clang --whatever
# ... hack on code ...
nss-ssl-gtests.sh -b TestSomething
# ... hack more ...
nss-ssl-gtests.sh -b TestSomething
# ... hack more ...
./build.sh --rebuild
```

Each time the `-b` option is used, the original build configuration is used, rather than building with default options.