### PR TITLE
Use bash instead of sh

### DIFF
--- a/nss-ssl-gtests.sh
+++ b/nss-ssl-gtests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [[ -z "$NSS_DIR" ]]; then
     NSS_DIR=$(hg root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null)
 fi


### PR DESCRIPTION
nss-ssl-gtests.sh uses `echo -n` for filter generation, which is a Bash feature not available in older `sh` shells. We should explicitly invoke bash, so filter generation works.

(Without this, filter strings are:
```
Run: /Users/jcjones/hg/dist/Debug/bin/ssl_gtest -d /Users/jcjones/hg/tests_results/security/localhost.4/ssl_gtests -v --gtest_filter=-n **DC** -n :-*.AlertBeforeServerHello/*:*.ConnectWithExpiredTicket*:*.HrrThenRemoveKeyShare/1:*.HrrThenRemoveSignatureAlgorithms/1:*.HrrThenRemoveSupportedGroups/1:*.KeyLogFile/*:*.ReplaceFirstClientRecordWithApplicationData/*:*.ReplaceFirstServerRecordWithApplicationData/*:*.RetryCookieEmpty/1:*.RetryCookieWithExtras/1:*.RetryStatefulDropCookie/1:*.ServerAuthBiggestRsa/*:*.WeakDHGroup/*:*/TlsCipherSuiteTest.*:*/TlsSignatureSchemeConfiguration.*:DatagramDrop13/*:DatagramPre13/TlsConnectDatagramPre13.*:TLSVersionRanges/*:TlsConnectDatagram13.AuthCompleteBeforeFinished:TlsConnectStreamTls13.TimePassesByDefault
```
)